### PR TITLE
Fixed relative CreateDir

### DIFF
--- a/fsys.go
+++ b/fsys.go
@@ -112,17 +112,22 @@ func choosePolicy(prompt *Prompt, dir string) (overwritePolicy, error) {
 	return overwritePolicy(n), nil
 }
 
-func isExist(path string) (bool, error) {
-	_, err := os.Stat(path)
-	if err == nil {
-		return true, nil
+func isExist(dir string) (bool, error) {
+	d, err := os.Open(dir)
+	if err != nil {
+		return false, err
+	}
+	defer d.Close()
+
+	_, err = d.Readdirnames(1)
+	if err != nil {
+		if err == io.EOF {
+			return false, nil
+		}
+		return false, err
 	}
 
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-
-	return false, err
+	return true, nil
 }
 
 func removeDir(dir string) error {

--- a/fsys.go
+++ b/fsys.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 )
 
@@ -143,7 +142,7 @@ func removeDir(dir string) error {
 	}
 
 	for _, name := range names {
-		if err = os.RemoveAll(path.Join(dir, name)); err != nil {
+		if err = os.RemoveAll(filepath.Join(dir, name)); err != nil {
 			return err
 		}
 	}

--- a/fsys.go
+++ b/fsys.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 )
 
@@ -26,7 +27,7 @@ func CreateDir(prompt *Prompt, root string, fsys fs.FS) error {
 	}
 
 	if policy == forceOverwrite {
-		if err := os.RemoveAll(root); err != nil {
+		if err := removeDir(root); err != nil {
 			return err
 		}
 	}
@@ -122,6 +123,27 @@ func isExist(path string) (bool, error) {
 	}
 
 	return false, err
+}
+
+func removeDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+
+	names, err := d.Readdirnames(-1)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range names {
+		if err = os.RemoveAll(path.Join(dir, name)); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func create(prompt *Prompt, path string, policy overwritePolicy) (io.WriteCloser, error) {


### PR DESCRIPTION
Initial implementation uses os.RemoveAll() to clear directory when prompted. By [design](https://cs.opensource.google/go/go/+/refs/tags/go1.17.3:src/os/removeall_at.go;l=25), it does not allow removing all files and directories in `.`. isExist() also fails to identify an empty `.` directory as empty.