### PR TITLE
Fix existing check on files

### DIFF
--- a/fsys.go
+++ b/fsys.go
@@ -147,9 +147,20 @@ func choosePolicy(prompt *Prompt, dir string) (overwritePolicy, error) {
 func isExist(dir string) (bool, error) {
 	d, err := os.Open(dir)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
 		return false, err
 	}
 	defer d.Close()
+
+	info, err := d.Stat()
+	if err != nil {
+		return false, err
+	}
+	if !info.IsDir() {
+		return true, nil
+	}
 
 	_, err = d.Readdirnames(1)
 	if err != nil {

--- a/fsys.go
+++ b/fsys.go
@@ -87,7 +87,7 @@ func CreateDir(prompt *Prompt, root string, fsys fs.FS, options ...CreatorOption
 			return err
 		}
 
-		if fi.Size() == 0 {
+		if !creator.includeEmpty && fi.Size() == 0 {
 			return nil
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,7 @@ require (
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )
 
-retract v0.1.0
+retract (
+	v0.3.0
+	v0.1.0
+)

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,12 @@ go 1.17
 
 require (
 	github.com/josharian/txtarfs v0.0.0-20210615234325-77aca6df5bca
+	golang.org/x/mod v0.4.2
 	golang.org/x/tools v0.1.7
 )
 
 require (
 	github.com/josharian/mapfs v0.0.0-20210615234106-095c008854e6 // indirect
-	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )


### PR DESCRIPTION
Previous implementation only works to check directory existence and fails to check for existence when a path to a file is given. This PR also fixes the inclusion of empty files in the creator, which was used incorrectly in the previous release.